### PR TITLE
Add automated build command with GCP bucket upload support

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -122,8 +122,17 @@ func defaultGcloudProject() (project string, err error) {
 func gcloud(out io.Writer, args ...string) error {
 	path, err := exec.LookPath("gcloud")
 	if err != nil {
-		home := "/" + path_util.Join("home", os.Getenv("USER"))
-		path = path_util.Join(home, "google-cloud-sdk", "bin", "gcloud")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("user home dir: %w", err)
+		}
+		parts := strings.Split(home, ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("unable to extract volume name from %q", home)
+		}
+		volume := parts[0] + ":"
+		path = path_util.Join(volume, "msys64", "home", os.Getenv("USER"))
+		path = path_util.Join(path, "google-cloud-sdk", "bin", "gcloud")
 	}
 	cmd := exec.Command(path, args...)
 	cmd.Stdout = os.Stdout

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -35,7 +35,7 @@ If you are an expert in cross-compilation you should be able to make it on any
 platform, but a the moment what was tested is documented in [docs/install.md].
 
 When using --push option, make sure either [gcloud] is available through your
-PATH setting or google-cloud-sdk is in your home directory. 
+PATH environment variable (e.g. export PATH=$PATH:$HOME/google-cloud-sdk/bin).
 		`,
 		Args: func(cmd *cobra.Command, args []string) (err error) {
 			if *push {
@@ -122,17 +122,7 @@ func defaultGcloudProject() (project string, err error) {
 func gcloud(out io.Writer, args ...string) error {
 	path, err := exec.LookPath("gcloud")
 	if err != nil {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("user home dir: %w", err)
-		}
-		parts := strings.Split(home, ":")
-		if len(parts) != 2 {
-			return fmt.Errorf("unable to extract volume name from %q", home)
-		}
-		volume := parts[0] + ":"
-		path = path_util.Join(volume, "msys64", "home", os.Getenv("USER"))
-		path = path_util.Join(path, "google-cloud-sdk", "bin", "gcloud")
+		return fmt.Errorf("look path gcloud: %w", err)
 	}
 	cmd := exec.Command(path, args...)
 	cmd.Stdout = os.Stdout

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -122,10 +122,7 @@ func defaultGcloudProject() (project string, err error) {
 func gcloud(out io.Writer, args ...string) error {
 	path, err := exec.LookPath("gcloud")
 	if err != nil {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("os user home dir: %w", err)
-		}
+		home := "/" + path_util.Join("home", os.Getenv("USER"))
 		path = path_util.Join(home, "google-cloud-sdk", "bin", "gcloud")
 	}
 	cmd := exec.Command(path, args...)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	path_util "path"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newCommandDev(version string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "dev",
+	}
+	cmd.AddCommand(
+		newCommandBuild(version),
+	)
+	return cmd
+}
+
+func newCommandBuild(version string) *cobra.Command {
+	var push *bool
+	var gitRemote, gcpBucket, gcpProject, output *string
+	cmd := &cobra.Command{
+		Use: "build",
+		Long: `
+Read docs/install.md first to setup you build environment.
+
+If you are an expert in cross-compilation you should be able to make it on any
+platform, but a the moment what was tested is documented in [docs/install.md].
+
+When using --push option, make sure either [gcloud] is available through your
+PATH setting or google-cloud-sdk is in your home directory. 
+		`,
+		Args: func(cmd *cobra.Command, args []string) (err error) {
+			if *push {
+				for _, opt := range []*string{gcpBucket, gcpProject, gitRemote, output} {
+					*opt = strings.TrimSpace(*opt)
+				}
+				if len(*gcpProject) == 0 {
+					*gcpProject, err = defaultGcloudProject()
+					if err != nil {
+						return fmt.Errorf("gcloud config get project: %w", err)
+					}
+				}
+				if len(*gitRemote) == 0 {
+					*gitRemote, err = defaultGitRemote()
+					if err != nil {
+						return fmt.Errorf("git remote: %w", err)
+					}
+				}
+				if len(*gcpBucket) == 0 {
+					return errors.New("--gcp-bucket is expected with --push")
+				}
+				if len(*output) == 0 {
+					return errors.New("--output is expected")
+				}
+				return nil
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if err = build(*output); err != nil {
+				return fmt.Errorf("go build: %w", err)
+			}
+			fmt.Println("built", version)
+			if !*push {
+				return nil
+			}
+			if err = gcloud(nil, "auth", "login"); err != nil {
+				return fmt.Errorf("gcloud auth login: %w", err)
+			}
+			dst := bucketFile("gs://"+*gcpBucket, version)
+			if err = gcloud(nil, "storage", "cp", "groq.exe", dst); err != nil {
+				return fmt.Errorf("copy %q to %q: %w", *output, dst, err)
+			}
+			fmt.Println("new version available at", bucketFile(
+				strings.Replace(remoteBucket, "groq-whisper", *gcpBucket, 1), version))
+			return nil
+
+		},
+	}
+	push = cmd.Flags().Bool("push", false, "push built version to upstream main and gcloud storage")
+	gitRemote = cmd.Flags().String("git-remote", "", "use first git remote if not set")
+	gcpBucket = cmd.Flags().String("gcp-bucket", "groq-whisper", "GCP storage bucket name")
+	gcpProject = cmd.Flags().String("gcp-project", "", "GCP project name (use default project if not set)")
+	output = cmd.Flags().String("output", "groq.exe", "go build output")
+	return cmd
+}
+
+func git(out io.Writer, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run git %v: %w", args, err)
+	}
+	return nil
+}
+
+func defaultGitRemote() (remote string, err error) {
+	var b bytes.Buffer
+	if err = git(&b, "remote"); err != nil {
+		return "", fmt.Errorf("git remote: %w", err)
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+func defaultGcloudProject() (project string, err error) {
+	var b bytes.Buffer
+	if err = gcloud(&b, "config", "get", "project"); err != nil {
+		return "", fmt.Errorf("gcloud config get project: %w", err)
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+func gcloud(out io.Writer, args ...string) error {
+	path, err := exec.LookPath("gcloud")
+	if err != nil {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("os user home dir: %w", err)
+		}
+		path = path_util.Join(home, "google-cloud-sdk", "bin", "gcloud")
+	}
+	cmd := exec.Command(path, args...)
+	cmd.Stdout = os.Stdout
+	if out != nil {
+		cmd.Stdout = out
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %q: %w", path, err)
+	}
+	return nil
+}
+
+func build(output string) error {
+	path, err := exec.LookPath("go")
+	if err != nil {
+		path = path_util.Join("mingw64", "lib", "go", "bin", "go")
+	}
+	cmd := exec.Command(path, "build", "-o", output)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run go build with %q: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,9 @@ func NewCLI(version string) *cobra.Command {
 		newCommandRecord(),
 		newCommandSidecar(),
 		newCommandVersion(version),
-		newCommandUpgrade(version))
+		newCommandUpgrade(version),
+		newCommandDev(version),
+	)
 	return cmd
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -49,6 +49,10 @@ func remoteVersion() (string, error) {
 	return upstreamVersion, nil
 }
 
+func bucketFile(remote, version string) string {
+	return fmt.Sprintf("%sgroq-%s.exe", remote, version)
+}
+
 func upgrade(current string) (bool, string, error) {
 	upstream, err := remoteVersion()
 	if err != nil {
@@ -59,7 +63,7 @@ func upgrade(current string) (bool, string, error) {
 	}
 	if err := func() (err error) {
 		var b bytes.Buffer
-		upgrade := fmt.Sprintf("%sgroq-%s.exe", remoteBucket, upstream)
+		upgrade := bucketFile(remoteBucket, upstream)
 		resp, err := http.Get(upgrade)
 		if err != nil {
 			return fmt.Errorf("http get %q: %w", upgrade, err)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -13,7 +13,7 @@ import (
 )
 
 const versionUrl = "https://raw.githubusercontent.com/malikbenkirane/groq-whisper/refs/heads/main/version.go"
-const remoteBucket = "https://storage.googleapis.com/groq-whisper/"
+const remoteBucket = "https://storage.googleapis.com/groq-whisper"
 
 func remoteVersion() (string, error) {
 	var upstreamVersion string
@@ -50,7 +50,7 @@ func remoteVersion() (string, error) {
 }
 
 func bucketFile(remote, version string) string {
-	return fmt.Sprintf("%sgroq-%s.exe", remote, version)
+	return fmt.Sprintf("%s/groq-%s.exe", remote, version)
 }
 
 func upgrade(current string) (bool, string, error) {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "testing"
+
+func TestVersion(t *testing.T) {
+	expected := "gs://groq-whisper/groq-v0.4.0.exe"
+	if bucketFile("gs://groq-whisper", "v0.4.0") != expected {
+		t.Logf("epected %q", expected)
+		t.Fail()
+	}
+	expected = remoteBucket + "/" + "groq-v0.4.0.exe"
+	if bucketFile(remoteBucket, "v0.4.0") != expected {
+		t.Logf("expected %q", expected)
+		t.Fail()
+	}
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -12,13 +12,33 @@ We currently are targeting platforms
 * Required packages (`pacman -S`):
 	+ `mingw-w64-x86_64-go`
 	+ `mingw-w64-x86_64-portaudio`
+    + `mingw-w64-x86_64-gcc` 
 
+## CGo dependencies and compilation suite configuration
+
+1. Install 
+   ```bash
+   pacman -S mingw-w64-x86_64-gcc
+   pacman -S mingw-w64-x86_64-portaudio
+   pacman -S mingw-w64-x86_64-pkg-config
+   ```
+
+2. Set `PATH` such that `mingw64/bin` takes precedence
+   ```bash
+   export PATH=/mingw64/bin:$PATH
+   ```
+
+4. Add `mingw64/lib/pkgconfig` to `PKG_CONFIG_PATH`
+   ```bash
+   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/mingw64/lib/pkgconfig
+   ```
 
 ## Go installation and configuration
 
 1. Install Go using pacman: `pacman -S mingw-w64-x86_64-go`
 2. Add Go bin directory to system PATH: `export PATH=/mingw64/lib/go/bin:$PATH`
 3. Enabled CGO compilation: `go env -w CGO_ENABLED=1`
+
 
 ## PortAudio setup
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -13,6 +13,7 @@ We currently are targeting platforms
 	+ `mingw-w64-x86_64-go`
 	+ `mingw-w64-x86_64-portaudio`
     + `mingw-w64-x86_64-gcc` 
+    + `mingw-w64-x86_64-pkg-config` 
 
 ## CGo dependencies and compilation suite configuration
 
@@ -35,23 +36,24 @@ We currently are targeting platforms
 
 ## Go installation and configuration
 
-1. Install Go using pacman: `pacman -S mingw-w64-x86_64-go`
-2. Add Go bin directory to system PATH: `export PATH=/mingw64/lib/go/bin:$PATH`
-3. Enabled CGO compilation: `go env -w CGO_ENABLED=1`
+1. Install Go using pacman:
+   ```bash
+   pacman -S mingw-w64-x86_64-go`
+   ```
 
+2. Add Go bin directory to system PATH:
+   ```bash
+   export PATH=/mingw64/lib/go/bin:$PATH
+   ```
 
-## PortAudio setup
-
-1. Set up `PKG_CONFIG` path for PortAudio (`.pc` file)
-2. Add pkg-config to system PATH ( suggested location: `/mingw64/bin` )
+3. Enabled CGO compilation:
+   ```bash
+   go env -w CGO_ENABLED=1
+   ```
 
 ## Missing Steps
 
-The following steps are missing and need to be completed:
-
-* How to verify the installation of PortAudio and Go packages?
-* Are there any specific configuration options or flags required for a successful build?
-
-> They might be other missing informations to uncover.
+> They might be missing or partially unavailable information to make this guide
+> strictly reproducible.
 
 **Contributions would help us improve the quality of this documentation.**

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,37 @@
+# Build instructions
+
+We currently are targeting platforms
+
+## Prerequisites
+
+* Target system: Windows x86_64
+* Tested build environment:
+	+ msys2 ucrt64
+	+ mingw64
+* `pacman -Syu`
+* Required packages (`pacman -S`):
+	+ `mingw-w64-x86_64-go`
+	+ `mingw-w64-x86_64-portaudio`
+
+
+## Go installation and configuration
+
+1. Install Go using pacman: `pacman -S mingw-w64-x86_64-go`
+2. Add Go bin directory to system PATH: `export PATH=/mingw64/lib/go/bin:$PATH`
+3. Enabled CGO compilation: `go env -w CGO_ENABLED=1`
+
+## PortAudio setup
+
+1. Set up `PKG_CONFIG` path for PortAudio (`.pc` file)
+2. Add pkg-config to system PATH ( suggested location: `/mingw64/bin` )
+
+## Missing Steps
+
+The following steps are missing and need to be completed:
+
+* How to verify the installation of PortAudio and Go packages?
+* Are there any specific configuration options or flags required for a successful build?
+
+> They might be other missing informations to uncover.
+
+**Contributions would help us improve the quality of this documentation.**

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "v0.3.0"
+const version = "v0.4.0"


### PR DESCRIPTION
Implements `dev build` command to automate compilation and release distribution, eliminating manual build and upload steps. This completes the release workflow where developers use `dev build --push` to publish binaries that end users download via the `upgrade` command.

### Key Changes

- **New `dev build` command** with optional `--push` flag for automated GCP bucket uploads
  - Auto-detects GCP project and Git remote from environment
  - Handles gcloud authentication automatically
  - Uses consistent `groq-{version}.exe` naming convention
- **Fix URL path construction bug** in upgrade module (trailing slash caused malformed URLs)
- **Simplify MSYS2 support** by only requiring proper PATH
- **Comprehensive Windows build documentation** covering CGo toolchain setup, pkg-config configuration, and required packages

### Notes

- Version bumped to v0.4.0
- to use `dev build --push` gcloud binary must now be added to PATH manually in MSYS2 environments: 
  ```bash
   export PATH=$PATH:$HOME/google-cloud-sdk/bin
   ```